### PR TITLE
캐슬링 조건 중 경로에 체크되면 안된다를 ruleManager에서 해결하려면 재귀에 빠져버리는 버그 발견하여 수정

### DIFF
--- a/app/src/main/java/io/github/breadkey/chess/model/chess/ChessRuleManager.java
+++ b/app/src/main/java/io/github/breadkey/chess/model/chess/ChessRuleManager.java
@@ -7,7 +7,6 @@ import java.util.List;
 import io.github.breadkey.chess.model.chess.chessPieces.King;
 
 public class ChessRuleManager {
-    private static final ChessRuleManager ourInstance = new ChessRuleManager();
     public enum Rule {
         Check,
         Checkmate,
@@ -17,7 +16,7 @@ public class ChessRuleManager {
     }
 
     public static ChessRuleManager getInstance() {
-        return ourInstance;
+        return new ChessRuleManager();
     }
 
     private ChessRuleManager() {
@@ -111,7 +110,6 @@ public class ChessRuleManager {
                 coordinates = filterAllyPiecePlaced(chessBoard, coordinates, division);
 
                 addCastlingCoordinate(chessBoard, piece, file, rank, coordinates);
-
                 break;
             }
         }
@@ -128,16 +126,13 @@ public class ChessRuleManager {
             List<Coordinate> lineCoordinates = new ArrayList<>();
             PlayChessService.Division enemyDivision = king.division == PlayChessService.Division.White ? PlayChessService.Division.Black : PlayChessService.Division.White;
             findRookCoordinatesCanMove(chessBoard, lineCoordinates, file, rank, enemyDivision);
-
             ChessPiece[] rooks = new ChessPiece[]{kingSideRook, queenSideRook};
 
             for (ChessPiece rook : rooks) {
                 if (rook != null && rook.moveCount == 0) {
                     if (lineCoordinates.contains(rook.getCoordinate())) {
                         int side = rook.getFile() > file? 1 : -1;
-                        if (!arePiecesCanMove(chessBoard, enemyDivision, new Coordinate((char) (file + side), rank))) {
-                            destination.add(new Coordinate((char) (file + side * 2), rank));
-                        }
+                        destination.add(new Coordinate((char) (file + side * 2), rank));
                     }
                 }
             }

--- a/app/src/main/java/io/github/breadkey/chess/model/chess/PlayChessService.java
+++ b/app/src/main/java/io/github/breadkey/chess/model/chess/PlayChessService.java
@@ -67,6 +67,14 @@ public class PlayChessService {
         if (pieceWillMove != null) {
             List coordinatesCanMove = ruleManager.findSquareCoordinateCanMove(chessBoard, fromFile, fromRank);
             coordinatesCanMove = ruleManager.filterKingCanDead(chessBoard, coordinatesCanMove, pieceWillMove);
+            if (pieceWillMove.type == ChessPiece.Type.King) {
+                if (!coordinatesCanMove.contains(new Coordinate((char) (pieceWillMove.getFile() + 1), pieceWillMove.getRank()))) {
+                    coordinatesCanMove.remove(new Coordinate((char) (pieceWillMove.getFile() + 2), pieceWillMove.getRank()));
+                }
+                if (!coordinatesCanMove.contains(new Coordinate((char) (pieceWillMove.getFile() - 1), pieceWillMove.getRank()))) {
+                    coordinatesCanMove.remove(new Coordinate((char) (pieceWillMove.getFile() - 2), pieceWillMove.getRank()));
+                }
+            }
 
             if (coordinatesCanMove.contains(new Coordinate(toFile, toRank))) {
                 move(pieceWillMove, toFile, toRank);

--- a/app/src/test/java/io/github/breadkey/chess/model/chess/ChessRuleManagerTest.java
+++ b/app/src/test/java/io/github/breadkey/chess/model/chess/ChessRuleManagerTest.java
@@ -284,16 +284,6 @@ public class ChessRuleManagerTest {
         assertTrue(coordinates.contains(new Coordinate('c', 1)));
     }
 
-    @Test
-    public void canNotCastlingBecauseCheck() {
-        chessBoard.placeNewPiece('e', 1, new King(PlayChessService.Division.White));
-        chessBoard.placeNewPiece('h', 1, new Rook(PlayChessService.Division.White));
-        chessBoard.placeNewPiece('f', 8, new Rook(PlayChessService.Division.Black));
-        List<Coordinate> coordinates = ruleManager.findSquareCoordinateCanMove(chessBoard, 'e', 1);
-
-        assertFalse(coordinates.contains(new Coordinate('g', 1)));
-    }
-
     private void assertCoordinatesContains(char file, int rank, List<Coordinate> coordinates) {
         assertTrue(coordinates.contains(new Coordinate(file, rank)));
     }

--- a/app/src/test/java/io/github/breadkey/chess/model/chess/PlayChessServiceTest.java
+++ b/app/src/test/java/io/github/breadkey/chess/model/chess/PlayChessServiceTest.java
@@ -279,6 +279,30 @@ public class PlayChessServiceTest {
         assertEquals(ChessPiece.Type.Rook, playChessService.getPieceAt('d', 1).getType());
     }
 
+    @Test
+    public void castlingProcess() {
+        playChessService.tryMove('e', 2, 'e', 4);
+        playChessService.tryMove('e', 7, 'e', 5);
+        playChessService.tryMove('f', 1, 'c', 4);
+        playChessService.tryMove('f', 8, 'c', 5);
+        playChessService.tryMove('g', 1, 'f', 3);
+        playChessService.tryMove('g', 8, 'f', 6);
+
+        System.out.print(playChessService.getChessBoard());
+    }
+
+    @Test
+    public void canNotCastlingBecauseCheck() {
+        playChessService.clearChessBoard();
+        playChessService.placeNewPiece('e', 1, new King(PlayChessService.Division.White));
+        playChessService.placeNewPiece('h', 1, new Rook(PlayChessService.Division.White));
+        playChessService.placeNewPiece('f', 8, new Rook(PlayChessService.Division.Black));
+        playChessService.placeNewPiece('e', 8, new King(PlayChessService.Division.Black));
+        playChessService.tryMove('e', 1, 'g', 1);
+
+        assertNull(playChessService.getPieceAt('g', 1));
+    }
+
     public void kill_b7PawnWith_a2Pawn() {
         playChessService.tryMove('a', 2, 'a', 4);
         playChessService.tryMove('b', 7, 'b', 5);


### PR DESCRIPTION
이 책임이 PlayChessService에 가면 안 될 것 같지만 일단 이게 제일 간단한 해결 방법...